### PR TITLE
Optimize swap operation for the same ranks

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -112,6 +112,7 @@ library HeapOrdering {
         uint256 _rank1,
         uint256 _rank2
     ) private {
+        if (_rank1 == _rank2) return;
         Account memory accountOldRank1 = getAccount(_heap, _rank1);
         Account memory accountOldRank2 = getAccount(_heap, _rank2);
         setAccount(_heap, _rank1, accountOldRank2);

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -503,4 +503,38 @@ contract TestHeapOrdering is DSTest {
 
         assertEq(heap.accounts[1].value, 25);
     }
+
+    function testInsertNoSwap() public {
+        update(accounts[0], 0, 40);
+        update(accounts[1], 0, 30);
+        update(accounts[2], 0, 20);
+
+        // Insert does a swap with the same ranks.
+        update(accounts[3], 0, 10);
+        assertEq(heap.ranks[accounts[0]], 1);
+        assertEq(heap.ranks[accounts[1]], 2);
+        assertEq(heap.ranks[accounts[2]], 3);
+        assertEq(heap.ranks[accounts[3]], 4);
+    }
+
+    function testIncreaseAndRemoveNoSwap() public {
+        MAX_SORTED_USERS = 4;
+        update(accounts[0], 0, 60);
+        update(accounts[1], 0, 50);
+        update(accounts[2], 0, 40);
+        update(accounts[3], 0, 30);
+
+        // Increase does a swap with the same ranks.
+        update(accounts[2], 40, 45);
+        assertEq(heap.ranks[accounts[0]], 1);
+        assertEq(heap.ranks[accounts[1]], 2);
+        assertEq(heap.ranks[accounts[2]], 3);
+        assertEq(heap.ranks[accounts[3]], 4);
+
+        // Remove does a swap with the same ranks.
+        update(accounts[3], 30, 0);
+        assertEq(heap.ranks[accounts[0]], 1);
+        assertEq(heap.ranks[accounts[1]], 2);
+        assertEq(heap.ranks[accounts[2]], 3);
+    }
 }


### PR DESCRIPTION
Fixes
- #32 
- #34 
- #37

Before the changes (only significant function is `update`):
![before-swap-same](https://user-images.githubusercontent.com/22668539/177501990-dc517997-d0c2-40ec-888b-2b50c99e2b24.png)
After the changes:
![after-swap-same](https://user-images.githubusercontent.com/22668539/177502018-b8742d75-a64b-417d-b120-7392844b6021.png)

