### PR TITLE
Downward traversal optimization

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -152,7 +152,9 @@ library HeapOrdering {
             if (childRank < size) {
                 rightChild = getAccount(_heap, childRank + 1);
                 if (rightChild.value > childToSwap.value) {
-                    childRank++;
+                    unchecked {
+                        ++childRank; // This cannot overflow because childRank < size.
+                    }
                     childToSwap = rightChild;
                 }
             }

--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -141,17 +141,21 @@ library HeapOrdering {
         Account memory accountToShift = getAccount(_heap, _rank);
         uint256 valueToShift = accountToShift.value;
         Account memory childToSwap;
+        Account memory rightChild;
         uint256 childRank = _rank << 1;
         // At this point, childRank (resp. childRank+1) is the rank of the left (resp. right) child.
 
         while (childRank <= size) {
-            // Compute the rank of the child with largest value.
-            if (
-                childRank < size &&
-                getAccount(_heap, childRank + 1).value > getAccount(_heap, childRank).value
-            ) childRank++;
-
             childToSwap = getAccount(_heap, childRank);
+
+            // Find the child with largest value.
+            if (childRank < size) {
+                rightChild = getAccount(_heap, childRank + 1);
+                if (rightChild.value > childToSwap.value) {
+                    childRank++;
+                    childToSwap = rightChild;
+                }
+            }
 
             if (childToSwap.value > valueToShift) {
                 setAccount(_heap, _rank, childToSwap);


### PR DESCRIPTION
Fixes 
- #33 

Before changes (only significant function is `updateHeap`):
![before-swap-same](https://user-images.githubusercontent.com/22668539/177507472-82cdbae6-e4fb-4fcd-bbb8-4820a9560d1b.png)

After changes:
![after-optimize-get](https://user-images.githubusercontent.com/22668539/177507513-c22723c2-32c8-4ecb-bfb4-4198a1f483a1.png)
