### PR TITLE
Upward traversal optimization

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -129,8 +129,11 @@ library HeapOrdering {
     function shiftUp(HeapArray storage _heap, uint256 _rank) private {
         Account memory accountToShift = getAccount(_heap, _rank);
         uint256 valueToShift = accountToShift.value;
-        while (_rank > ROOT && valueToShift > getAccount(_heap, _rank >> 1).value) {
-            setAccount(_heap, _rank, getAccount(_heap, _rank >> 1));
+        Account memory parentAccount;
+        while (
+            _rank > ROOT && valueToShift > (parentAccount = getAccount(_heap, _rank >> 1)).value
+        ) {
+            setAccount(_heap, _rank, parentAccount);
             _rank >>= 1;
         }
         setAccount(_heap, _rank, accountToShift);


### PR DESCRIPTION
Fixes 
- #39 

Before changes (only significant function is `updateHeap`):
![before-swap-same](https://user-images.githubusercontent.com/22668539/177512001-f4e2cb35-b2cc-4ca1-8710-4a8ba85a70cc.png)

After changes:
![after-shiftup-break](https://user-images.githubusercontent.com/22668539/177512057-42859fdd-b9e9-46a7-9341-d69b191df7a3.png)
