### PR TITLE
Removal upward shift optimization

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -252,10 +252,11 @@ library HeapOrdering {
         _heap.accounts.pop();
         delete _heap.ranks[_id];
 
-        // If the swapped account is in the heap, restore the invariant: its value can be smaller or larger than the removed value.
+        // If the swapped account is in the heap, restore the invariant: its current value can be smaller or larger than the removed value.
         if (rank <= _heap.size) {
-            if (_removedValue > getAccount(_heap, rank).value) shiftDown(_heap, rank);
-            else shiftUp(_heap, rank);
+            uint256 currentValue = getAccount(_heap, rank).value;
+            if (_removedValue > currentValue) shiftDown(_heap, rank);
+            else if (_removedValue < currentValue) shiftUp(_heap, rank);
         }
     }
 


### PR DESCRIPTION
Fixes
- #38 

These changes seems unlikely to save gas in our case: the amounts will all be different because of the interests earn. So even if 2 person supply exactly the same amount, if one does so one block after the other, the amounts will be different.

Before changes (only significant function is `updateHeap`):
![before-swap-same](https://user-images.githubusercontent.com/22668539/177517062-5ca185c0-1f0e-4656-8f59-50622b6b6442.png)

After changes:
![after-remove-shiftup](https://user-images.githubusercontent.com/22668539/177517129-a803d096-20ee-468c-b468-744103cad5ed.png)
