### PR TITLE
Use indexes instead of ranks

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -12,7 +12,7 @@ library HeapOrdering {
     struct HeapArray {
         Account[] accounts; // All the accounts.
         uint256 size; // The size of the heap portion of the structure, should be less than accounts length, the rest is an unordered array.
-        mapping(address => uint256) indexes; // A mapping from an address to an index in accounts.
+        mapping(address => uint256) indexes; // A mapping from an address to an index in accounts. From index i, the parent index is (i-1)/2, the left child index is 2*i+1 and the right child index is 2*i+2.
     }
 
     /// CONSTANTS ///

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -436,18 +436,18 @@ contract TestHeapOrdering is DSTest {
         MAX_SORTED_USERS = 4;
         for (uint256 i = 0; i < 16; i++) update(accounts[i], 0, 20 - i);
 
-        uint256 index5Before = heap.indexes[accounts[5]];
-        uint256 index0Before = heap.indexes[accounts[0]];
+        uint256 index5Before = heap.indexOf[accounts[5]];
+        uint256 index0Before = heap.indexOf[accounts[0]];
 
         update(accounts[5], 15, 1);
 
-        uint256 index5After = heap.indexes[accounts[5]];
+        uint256 index5After = heap.indexOf[accounts[5]];
 
         assertEq(index5Before, index5After);
 
         update(accounts[0], 20, 2);
 
-        uint256 index0After = heap.indexes[accounts[0]];
+        uint256 index0After = heap.indexOf[accounts[0]];
 
         assertGt(index0After, index0Before);
     }
@@ -459,7 +459,7 @@ contract TestHeapOrdering is DSTest {
 
         update(accounts[17], 20 - 17, 5);
 
-        uint256 index17After = heap.indexes[accounts[17]];
+        uint256 index17After = heap.indexOf[accounts[17]];
 
         assertEq(index17After, 5);
     }
@@ -471,7 +471,7 @@ contract TestHeapOrdering is DSTest {
 
         update(accounts[17], 20 - 17, 40);
 
-        uint256 index17After = heap.indexes[accounts[17]];
+        uint256 index17After = heap.indexOf[accounts[17]];
 
         assertEq(index17After, 0);
     }
@@ -526,10 +526,10 @@ contract TestHeapOrdering is DSTest {
 
         // Insert does a swap with the same index.
         update(accounts[3], 0, 10);
-        assertEq(heap.indexes[accounts[0]], 0);
-        assertEq(heap.indexes[accounts[1]], 1);
-        assertEq(heap.indexes[accounts[2]], 2);
-        assertEq(heap.indexes[accounts[3]], 3);
+        assertEq(heap.indexOf[accounts[0]], 0);
+        assertEq(heap.indexOf[accounts[1]], 1);
+        assertEq(heap.indexOf[accounts[2]], 2);
+        assertEq(heap.indexOf[accounts[3]], 3);
     }
 
     function testIncreaseAndRemoveNoSwap() public {
@@ -541,16 +541,16 @@ contract TestHeapOrdering is DSTest {
 
         // Increase does a swap with the same index.
         update(accounts[2], 40, 45);
-        assertEq(heap.indexes[accounts[0]], 0);
-        assertEq(heap.indexes[accounts[1]], 1);
-        assertEq(heap.indexes[accounts[2]], 2);
-        assertEq(heap.indexes[accounts[3]], 3);
+        assertEq(heap.indexOf[accounts[0]], 0);
+        assertEq(heap.indexOf[accounts[1]], 1);
+        assertEq(heap.indexOf[accounts[2]], 2);
+        assertEq(heap.indexOf[accounts[3]], 3);
 
         // Remove does a swap with the same index.
         update(accounts[3], 30, 0);
-        assertEq(heap.indexes[accounts[0]], 0);
-        assertEq(heap.indexes[accounts[1]], 1);
-        assertEq(heap.indexes[accounts[2]], 2);
+        assertEq(heap.indexOf[accounts[0]], 0);
+        assertEq(heap.indexOf[accounts[1]], 1);
+        assertEq(heap.indexOf[accounts[2]], 2);
     }
 
     function testOverflowNewValue() public {

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "ds-test/test.sol";
 import "forge-std/Vm.sol";
+import "forge-std/console.sol";
 
 import "@contracts/HeapOrdering.sol";
 
@@ -34,6 +35,16 @@ contract TestHeapOrdering is DSTest {
         }
     }
 
+    function testEmpty() public {
+        assertEq(heap.size, 0);
+        assertEq(heap.length(), 0);
+        assertEq(heap.getValueOf(accounts[0]), 0);
+        assertEq(heap.getHead(), ADDR_ZERO);
+        assertEq(heap.getTail(), ADDR_ZERO);
+        assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[0]), ADDR_ZERO);
+    }
+
     function testInsertOneSingleAccount() public {
         update(accounts[0], 0, 1);
 
@@ -44,6 +55,8 @@ contract TestHeapOrdering is DSTest {
         assertEq(heap.getTail(), accounts[0]);
         assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
         assertEq(heap.getNext(accounts[0]), ADDR_ZERO);
+
+        assertEq(heap.getValueOf(accounts[1]), 0);
     }
 
     function testShouldNotInsertAccountWithZeroValue() public {
@@ -107,6 +120,9 @@ contract TestHeapOrdering is DSTest {
         assertEq(heap.getNext(accounts[0]), accounts[1]);
         assertEq(heap.getPrev(accounts[1]), accounts[0]);
         assertEq(heap.getNext(accounts[1]), ADDR_ZERO);
+
+        assertEq(heap.getNext(accounts[2]), ADDR_ZERO);
+        assertEq(heap.getPrev(accounts[2]), ADDR_ZERO);
     }
 
     function testShouldInsertThreeAccounts() public {
@@ -420,20 +436,20 @@ contract TestHeapOrdering is DSTest {
         MAX_SORTED_USERS = 4;
         for (uint256 i = 0; i < 16; i++) update(accounts[i], 0, 20 - i);
 
-        uint256 rank5Before = heap.ranks[accounts[5]];
-        uint256 rank0Before = heap.ranks[accounts[0]];
+        uint256 index5Before = heap.indexes[accounts[5]];
+        uint256 index0Before = heap.indexes[accounts[0]];
 
         update(accounts[5], 15, 1);
 
-        uint256 rank5After = heap.ranks[accounts[5]];
+        uint256 index5After = heap.indexes[accounts[5]];
 
-        assertEq(rank5Before, rank5After);
+        assertEq(index5Before, index5After);
 
         update(accounts[0], 20, 2);
 
-        uint256 rank0After = heap.ranks[accounts[0]];
+        uint256 index0After = heap.indexes[accounts[0]];
 
-        assertGt(rank0After, rank0Before);
+        assertGt(index0After, index0Before);
     }
 
     function testIncreaseRankChange() public {
@@ -443,9 +459,9 @@ contract TestHeapOrdering is DSTest {
 
         update(accounts[17], 20 - 17, 5);
 
-        uint256 rank17After = heap.ranks[accounts[17]];
+        uint256 index17After = heap.indexes[accounts[17]];
 
-        assertEq(rank17After, 6);
+        assertEq(index17After, 5);
     }
 
     function testIncreaseRankChangeShiftUp() public {
@@ -455,9 +471,9 @@ contract TestHeapOrdering is DSTest {
 
         update(accounts[17], 20 - 17, 40);
 
-        uint256 rank17After = heap.ranks[accounts[17]];
+        uint256 index17After = heap.indexes[accounts[17]];
 
-        assertEq(rank17After, 1);
+        assertEq(index17After, 0);
     }
 
     function testRemoveLast() public {
@@ -508,12 +524,12 @@ contract TestHeapOrdering is DSTest {
         update(accounts[1], 0, 30);
         update(accounts[2], 0, 20);
 
-        // Insert does a swap with the same ranks.
+        // Insert does a swap with the same index.
         update(accounts[3], 0, 10);
-        assertEq(heap.ranks[accounts[0]], 1);
-        assertEq(heap.ranks[accounts[1]], 2);
-        assertEq(heap.ranks[accounts[2]], 3);
-        assertEq(heap.ranks[accounts[3]], 4);
+        assertEq(heap.indexes[accounts[0]], 0);
+        assertEq(heap.indexes[accounts[1]], 1);
+        assertEq(heap.indexes[accounts[2]], 2);
+        assertEq(heap.indexes[accounts[3]], 3);
     }
 
     function testIncreaseAndRemoveNoSwap() public {
@@ -523,18 +539,18 @@ contract TestHeapOrdering is DSTest {
         update(accounts[2], 0, 40);
         update(accounts[3], 0, 30);
 
-        // Increase does a swap with the same ranks.
+        // Increase does a swap with the same index.
         update(accounts[2], 40, 45);
-        assertEq(heap.ranks[accounts[0]], 1);
-        assertEq(heap.ranks[accounts[1]], 2);
-        assertEq(heap.ranks[accounts[2]], 3);
-        assertEq(heap.ranks[accounts[3]], 4);
+        assertEq(heap.indexes[accounts[0]], 0);
+        assertEq(heap.indexes[accounts[1]], 1);
+        assertEq(heap.indexes[accounts[2]], 2);
+        assertEq(heap.indexes[accounts[3]], 3);
 
-        // Remove does a swap with the same ranks.
+        // Remove does a swap with the same index.
         update(accounts[3], 30, 0);
-        assertEq(heap.ranks[accounts[0]], 1);
-        assertEq(heap.ranks[accounts[1]], 2);
-        assertEq(heap.ranks[accounts[2]], 3);
+        assertEq(heap.indexes[accounts[0]], 0);
+        assertEq(heap.indexes[accounts[1]], 1);
+        assertEq(heap.indexes[accounts[2]], 2);
     }
 
     function testOverflowNewValue() public {

--- a/test-foundry/TestStessHeapOrdering.t.sol
+++ b/test-foundry/TestStessHeapOrdering.t.sol
@@ -14,8 +14,8 @@ contract HeapStorage {
     function setUp() public {
         for (uint256 i = 0; i < TESTED_SIZE; i++) {
             address id = address(uint160(i + 1));
+            heap.indexes[id] = heap.accounts.length;
             heap.accounts.push(HeapOrdering.Account(id, uint96(TESTED_SIZE - i)));
-            heap.ranks[id] = heap.accounts.length;
             heap.size = MAX_SORTED_USERS;
         }
     }

--- a/test-foundry/TestStessHeapOrdering.t.sol
+++ b/test-foundry/TestStessHeapOrdering.t.sol
@@ -14,7 +14,7 @@ contract HeapStorage {
     function setUp() public {
         for (uint256 i = 0; i < TESTED_SIZE; i++) {
             address id = address(uint160(i + 1));
-            heap.indexes[id] = heap.accounts.length;
+            heap.indexOf[id] = heap.accounts.length;
             heap.accounts.push(HeapOrdering.Account(id, uint96(TESTED_SIZE - i)));
             heap.size = MAX_SORTED_USERS;
         }


### PR DESCRIPTION
Inspired by the MEP squad.

This PR goes back to using indexes. For an index `i`, calculations are now the following:
- left child is at `2*i+1`
- right child is at `2*i+2`
- parent is at `(i-1)/2`

The key idea is that you can still check that an address `id != address(0)` is in the heap `heap` with the condition:
`heap.accounts[heap.indexes[id]].id == id`

This simplifies the code and seems to be a bit better in terms of gas usage. Before changes (only significant function is `updateHeap`):
![before-indexes](https://user-images.githubusercontent.com/22668539/179227639-06aa4092-05e1-4ace-912d-abbab1c917aa.png)
After changes:
![after-index](https://user-images.githubusercontent.com/22668539/179228677-41b47b30-7063-4427-9bb8-e740b1b69cf7.png)
